### PR TITLE
Feature/transitview

### DIFF
--- a/iSEPTA/iSEPTA.xcodeproj/project.pbxproj
+++ b/iSEPTA/iSEPTA.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		0E36308D21001DB300980EB6 /* TransitRouteCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E36308C21001DB300980EB6 /* TransitRouteCardView.swift */; };
 		0E36308F21001DC500980EB6 /* TransitRouteCardView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0E36308E21001DC500980EB6 /* TransitRouteCardView.xib */; };
 		0E3630B32102118800980EB6 /* TransitViewAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E3630B22102118800980EB6 /* TransitViewAnnotationView.swift */; };
+		0E3630D62108A41100980EB6 /* TransitViewService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E3630D52108A41100980EB6 /* TransitViewService.swift */; };
 		0E39082E20E1268900E94D53 /* InAppReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E39082D20E1268900E94D53 /* InAppReview.swift */; };
 		0E39084C20E2E7B100E94D53 /* StopSortOrderButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E39084B20E2E7B100E94D53 /* StopSortOrderButton.swift */; };
 		0E4328E320D02C6400FBD805 /* DatabaseUpdateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4328E220D02C6400FBD805 /* DatabaseUpdateProvider.swift */; };
@@ -709,6 +710,7 @@
 		0E36308C21001DB300980EB6 /* TransitRouteCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransitRouteCardView.swift; sourceTree = "<group>"; };
 		0E36308E21001DC500980EB6 /* TransitRouteCardView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TransitRouteCardView.xib; sourceTree = "<group>"; };
 		0E3630B22102118800980EB6 /* TransitViewAnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransitViewAnnotationView.swift; sourceTree = "<group>"; };
+		0E3630D52108A41100980EB6 /* TransitViewService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransitViewService.swift; sourceTree = "<group>"; };
 		0E39082D20E1268900E94D53 /* InAppReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppReview.swift; sourceTree = "<group>"; };
 		0E39084B20E2E7B100E94D53 /* StopSortOrderButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopSortOrderButton.swift; sourceTree = "<group>"; };
 		0E4328E220D02C6400FBD805 /* DatabaseUpdateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseUpdateProvider.swift; sourceTree = "<group>"; };
@@ -1368,6 +1370,14 @@
 				0E4328E720D060DF00FBD805 /* DatabaseDownloadProvider.swift */,
 			);
 			path = "Database Providers";
+			sourceTree = "<group>";
+		};
+		0E3630D42108A3F300980EB6 /* Network Services */ = {
+			isa = PBXGroup;
+			children = (
+				0E3630D52108A41100980EB6 /* TransitViewService.swift */,
+			);
+			path = "Network Services";
 			sourceTree = "<group>";
 		};
 		0E4328E420D04AB500FBD805 /* Database */ = {
@@ -2398,6 +2408,7 @@
 				582F4EB31F33B1120062A546 /* Main */,
 				582F4E7F1F33B1120062A546 /* Utlities */,
 				582F4E811F33B1120062A546 /* Common Views */,
+				0E3630D42108A3F300980EB6 /* Network Services */,
 			);
 			path = iSEPTA;
 			sourceTree = "<group>";
@@ -3503,6 +3514,7 @@
 				0E8E60E920F006F900AB08FE /* FilterableTransitRoute.swift in Sources */,
 				67F757B31F48729C00D3A4EE /* UIView+Util.swift in Sources */,
 				58126F6F1F631C8300A6E187 /* NextToArriveMapRouteViewModel.swift in Sources */,
+				0E3630D62108A41100980EB6 /* TransitViewService.swift in Sources */,
 				58AF5FEA20F4F1FF00620484 /* NextToArriveReverseTrip.swift in Sources */,
 				67C567271F59695900FF6203 /* Favorite.swift in Sources */,
 				582F4EC71F33B1120062A546 /* SchedulesRoutesViewModel.swift in Sources */,

--- a/iSEPTA/iSEPTA/Features/Schedules/Routes/RouteTableViewCell.swift
+++ b/iSEPTA/iSEPTA/Features/Schedules/Routes/RouteTableViewCell.swift
@@ -14,6 +14,8 @@ class RouteTableViewCell: UITableViewCell, RouteCellDisplayable {
     @IBOutlet private var routeLongNameLabel: UILabel!
     @IBOutlet private var iconImageView: UIImageView!
 
+    var alertsAreInteractive: Bool = true
+
     var targetForScheduleAction: TargetForScheduleAction! { return store.state.targetForScheduleActions() }
 
     @IBOutlet var stackView: UIStackView! {
@@ -52,10 +54,12 @@ class RouteTableViewCell: UITableViewCell, RouteCellDisplayable {
     }
 
     @objc func gestureReognizerTapped(gr: UITapGestureRecognizer) {
-        gr.cancelsTouchesInView = true
-        let dismissModalAction = DismissModal(description: "Dismissing the modal to switch tabs")
-        store.dispatch(dismissModalAction)
-        let switchTabsAction = SwitchTabs(activeNavigationController: .alerts, description: "User tapped on alert")
-        store.dispatch(switchTabsAction)
+        if alertsAreInteractive {
+            gr.cancelsTouchesInView = true
+            let dismissModalAction = DismissModal(description: "Dismissing the modal to switch tabs")
+            store.dispatch(dismissModalAction)
+            let switchTabsAction = SwitchTabs(activeNavigationController: .alerts, description: "User tapped on alert")
+            store.dispatch(switchTabsAction)
+        }
     }
 }

--- a/iSEPTA/iSEPTA/Features/TransitView/Map/TransitRouteCardView.swift
+++ b/iSEPTA/iSEPTA/Features/TransitView/Map/TransitRouteCardView.swift
@@ -20,7 +20,12 @@ class TransitRouteCardView: UIView {
     @IBOutlet var modeImage: UIImageView!
     @IBOutlet var routeIdLabel: UILabel!
     @IBOutlet var dividerLine: UIView!
-    @IBOutlet var alertStackView: UIStackView!
+
+    @IBOutlet var alertStackView: UIStackView! {
+        didSet {
+            alertStackView.isExclusiveTouch = true
+        }
+    }
 
     @IBOutlet var tappableDeleteView: UIView! {
         didSet {
@@ -49,6 +54,7 @@ class TransitRouteCardView: UIView {
     }
 
     var delegate: TransitRouteCardDelegate?
+    var alertsAreInteractive = true
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -60,12 +66,19 @@ class TransitRouteCardView: UIView {
         setup()
     }
 
+    func addAlert(_ alert: SeptaAlert?) {
+        alertStackView.addAlert(alert)
+    }
+
     private func setup() {
         loadFromNib()
         alpha = 0 // Hide initially
         cornerRadius = 5
         layer.borderWidth = 1
         addStandardDropShadow()
+
+        let alertsTappedGesture = UITapGestureRecognizer(target: self, action: #selector(alertsTapped(gr:)))
+        alertStackView.addGestureRecognizer(alertsTappedGesture)
     }
 
     private func loadFromNib() {
@@ -89,6 +102,14 @@ class TransitRouteCardView: UIView {
             store.dispatch(TransitViewRemoveRoute(route: route, description: "User wishes to remove a TransitView route from the map"))
         }))
         alert.show()
+    }
+
+    @objc func alertsTapped(gr: UITapGestureRecognizer) {
+        if alertsAreInteractive {
+            gr.cancelsTouchesInView = true
+            let switchTabsAction = SwitchTabs(activeNavigationController: .alerts, description: "User tapped on alert from TransitView")
+            store.dispatch(switchTabsAction)
+        }
     }
 }
 

--- a/iSEPTA/iSEPTA/Features/TransitView/Map/TransitRouteCardView.xib
+++ b/iSEPTA/iSEPTA/Features/TransitView/Map/TransitRouteCardView.xib
@@ -68,17 +68,19 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XeV-DB-cPU">
                     <rect key="frame" x="9" y="55" width="123" height="16"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="pGA-B5-U1l">
-                            <rect key="frame" x="0.0" y="0.0" width="123" height="16"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" alignment="center" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="pGA-B5-U1l">
+                            <rect key="frame" x="50.5" y="0.0" width="22" height="16"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="22" placeholder="YES" id="rrq-9b-hml"/>
+                            </constraints>
                         </stackView>
                     </subviews>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="bottom" secondItem="pGA-B5-U1l" secondAttribute="bottom" id="2CC-uQ-RUc"/>
-                        <constraint firstAttribute="trailing" secondItem="pGA-B5-U1l" secondAttribute="trailing" id="5qr-Qv-dQD"/>
+                        <constraint firstItem="pGA-B5-U1l" firstAttribute="centerX" secondItem="XeV-DB-cPU" secondAttribute="centerX" id="a9O-46-mCA"/>
                         <constraint firstAttribute="height" constant="16" id="h5b-Jy-EzH"/>
                         <constraint firstItem="pGA-B5-U1l" firstAttribute="top" secondItem="XeV-DB-cPU" secondAttribute="top" id="io9-XA-gMH"/>
-                        <constraint firstItem="pGA-B5-U1l" firstAttribute="leading" secondItem="XeV-DB-cPU" secondAttribute="leading" id="ugl-G1-kUd"/>
                     </constraints>
                 </view>
             </subviews>

--- a/iSEPTA/iSEPTA/Features/TransitView/Map/TransitViewMapViewController.swift
+++ b/iSEPTA/iSEPTA/Features/TransitView/Map/TransitViewMapViewController.swift
@@ -17,6 +17,7 @@ class TransitViewMapViewController: UIViewController, StoreSubscriber {
     var viewModel = TransitViewMapRouteViewModel()
     var routesHaveBeenAdded = false
     var selectedRoute: TransitRoute?
+    var updateMap = true
 
     @IBOutlet var mapView: MKMapView! {
         didSet {
@@ -114,8 +115,13 @@ class TransitViewMapViewController: UIViewController, StoreSubscriber {
             guard let _ = mapView else { return }
             clearExistingVehicleLocations()
             drawVehicleLocations()
-            mapView.showAnnotations(mapView.annotations, animated: false)
-            mapView.setVisibleMapRect(mapView.visibleMapRect, edgePadding: UIEdgeInsets(top: 25, left: 0, bottom: 25, right: 0), animated: true)
+            if updateMap {
+                mapView.showAnnotations(mapView.annotations, animated: false)
+                mapView.setVisibleMapRect(mapView.visibleMapRect, edgePadding: UIEdgeInsets(top: 25, left: 0, bottom: 25, right: 0), animated: true)
+            }
+            if !updateMap {
+                updateMap = true
+            }
             vehiclesToAdd.removeAll()
         }
     }
@@ -270,6 +276,9 @@ extension TransitViewMapViewController: TransitRouteCardDelegate {
 
 extension TransitViewMapViewController: TransitViewAnnotationViewDelegate {
     func activateRoute(routeId: String) {
+        // Just switching active route, so don't update the whole map
+        updateMap = false
+
         // Set new active route ID
         activateRouteById(routeId: routeId)
 
@@ -289,7 +298,7 @@ extension TransitViewMapViewController: TransitViewAnnotationViewDelegate {
         // Clear old annotations
         let previouslyAddedAnnotations = vehicleAnnotationsAdded.map { $0.location }
         clearExistingVehicleLocations()
-        
+
         // Add annotations back
         vehiclesToAdd = previouslyAddedAnnotations
     }

--- a/iSEPTA/iSEPTA/Features/TransitView/Select Route/TransitViewRoutesViewModel.swift
+++ b/iSEPTA/iSEPTA/Features/TransitView/Select Route/TransitViewRoutesViewModel.swift
@@ -83,6 +83,8 @@ class TransitViewRoutesViewModel: NSObject, StoreSubscriber, UITextFieldDelegate
             cell.setIcon(image: routeImage)
         }
 
+        // Configure alerts
+        cell.alertsAreInteractive = false // Alert icons are informative only
         let alert = alerts[route.mode()]?[route.routeId]
         cell.addAlert(alert)
     }

--- a/iSEPTA/iSEPTA/Features/TransitView/Select Route/TransitViewRoutesViewModel.swift
+++ b/iSEPTA/iSEPTA/Features/TransitView/Select Route/TransitViewRoutesViewModel.swift
@@ -16,6 +16,8 @@ class TransitViewRoutesViewModel: NSObject, StoreSubscriber, UITextFieldDelegate
     var slotBeingChanged: TransitViewRouteSlot?
     var selectedRoutes: [TransitRoute] = []
 
+    let alerts = store.state.alertState.alertDict
+
     var allRoutes: [TransitRoute]? {
         didSet {
             guard let allRoutes = allRoutes else { return }
@@ -80,6 +82,9 @@ class TransitViewRoutesViewModel: NSObject, StoreSubscriber, UITextFieldDelegate
         if let routeImage = RouteIcon.get(for: route.routeId, transitMode: route.mode()) {
             cell.setIcon(image: routeImage)
         }
+
+        let alert = alerts[route.mode()]?[route.routeId]
+        cell.addAlert(alert)
     }
 
     func shouldHighlight(row: Int) -> Bool {

--- a/iSEPTA/iSEPTA/Info/Info.plist
+++ b/iSEPTA/iSEPTA/Info/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.0.17</string>
 	<key>CFBundleVersion</key>
-	<string>163</string>
+	<string>164</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/iSEPTA/iSEPTA/Network Services/TransitViewService.swift
+++ b/iSEPTA/iSEPTA/Network Services/TransitViewService.swift
@@ -1,0 +1,31 @@
+//
+//  TransitViewService.swift
+//  iSEPTA
+//
+//  Created by Mike Mannix on 7/25/18.
+//  Copyright © 2018 Mark Broski. All rights reserved.
+//
+
+import SeptaRest
+
+class TransitViewService {
+    let network = SeptaNetwork.sharedInstance
+
+    func transitViewDataTask(for routeIds: [String], completion: @escaping (Data?, URLResponse?, Swift.Error?) -> Void) -> URLSessionDataTask {
+        let urlString = urlWithRouteIds(routeIds: routeIds)
+        guard let url = URL(string: urlString) else { return URLSessionDataTask() }
+        var request = URLRequest(url: url)
+        request.setValue(network.apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        return URLSession.shared.dataTask(with: request, completionHandler: completion)
+    }
+
+    private func urlWithRouteIds(routeIds: [String]) -> String {
+        var url = "\(network.url)/transitviewall?routes="
+        for route in routeIds {
+            url.append("\(route),")
+        }
+        url.removeLast() // remove last comma
+        return url
+    }
+}

--- a/iSEPTA/iSEPTA/State Providers/TransitViewVehicleLocationDataProvider.swift
+++ b/iSEPTA/iSEPTA/State Providers/TransitViewVehicleLocationDataProvider.swift
@@ -58,11 +58,8 @@ class TransitViewVehicleLocationDataProvider: StoreSubscriber {
             UIApplication.shared.isNetworkActivityIndicatorVisible = true
         }
 
-        let urlString = urlWithRouteIds(routeIds: routeIds)
-        guard let url = URL(string: urlString) else { return }
-
-        let downloadTask = URLSession.shared.dataTask(with: url) { data, _, error in
-
+        let service = TransitViewService()
+        let downloadTask = service.transitViewDataTask(for: routeIds) { data, _, error in
             DispatchQueue.main.async {
                 UIApplication.shared.isNetworkActivityIndicatorVisible = false
             }
@@ -83,15 +80,6 @@ class TransitViewVehicleLocationDataProvider: StoreSubscriber {
             }
         }
         downloadTask.resume()
-    }
-
-    private func urlWithRouteIds(routeIds: [String]) -> String {
-        var urlString = "http://apitest.septa.org/api/TransitViewAll/index.php?routes="
-        for route in routeIds {
-            urlString.append("\(route),")
-        }
-        urlString.removeLast() // remove last comma
-        return urlString
     }
 
     private func convertToVehicleLocations(_ routeData: TransitViewRouteData, model: TransitViewModel) -> [TransitViewVehicleLocation] {


### PR DESCRIPTION
TransitView Updates
- Add service alerts to route picker and route map cards
- Introduce interactive toggle to fulfill requirement of alerts not being tappable when a card is not selected
- Introduce "moveMap" toggle to allow control over when the map is adjusted to fit annotations. This fulfills a requirement where switching the active route on the map does not move the map
- Move the TransitView network call out of the provider and into a dedicated network service object